### PR TITLE
Include Rules tests into runnable elements

### DIFF
--- a/lib/cuke_slicer/extractors/file_extractor.rb
+++ b/lib/cuke_slicer/extractors/file_extractor.rb
@@ -19,6 +19,7 @@ module CukeSlicer
       [].tap do |test_cases|
         unless target.feature.nil?
           tests = target.feature.tests
+          tests += target.feature.rules.flat_map(&:tests)
 
           runnable_elements = extract_runnable_elements(extract_runnable_block_elements(tests, filters, &block))
 

--- a/testing/cucumber/features/test_case_extraction.feature
+++ b/testing/cucumber/features/test_case_extraction.feature
@@ -82,3 +82,25 @@ Feature: Test case extraction
     And the test cases are to be extracted as objects
     When test cases are extracted from it
     Then the test cases are provided as objects
+
+  Scenario: Extract tests in Rules
+    Given the following feature file "a_test.feature":
+      """
+      Feature: A test feature
+
+        Scenario: Test 1
+          * some steps
+
+        Rule: Rule 1
+          Scenario Outline: Test 2
+            * some steps
+          Examples: Block 1
+            | param | value |
+            | a     | 1     |
+            | b     | 2     |
+      """
+    When test cases are extracted from it
+    Then the following test cases are found
+      | path/to/a_test.feature:3  |
+      | path/to/a_test.feature:11 |
+      | path/to/a_test.feature:12 |


### PR DESCRIPTION
When using cuke_slicer on feature files using Rule keywords, the tests include in these Rules are not present into the slicer returned by cuke_slicer.

**Example**

When this Feature file is inspected by CukeSlicer:

``` genkins
Feature: A test feature

  Scenario: Test 1
    * some steps

  Rule: Rule 1
    Scenario Outline: Test 2
      * some steps
    Examples: Block 1
      | param | value |
      | a     | 1     |
      | b     | 2     |
```

The returned slice only contains the Scenario defined out of the Rule keyword:

``` ruby
CukeSlicer::Slicer.new.slice('path/to/a_test.feature', :file_line) 
=> [ "path/to/a_test.feature:3" ]
```

_Actual_

```
path/to/a_test.feature:3
```

_Expected_

```
path/to/a_test.feature:3 
path/to/a_test.feature:11
path/to/a_test.feature:12
```

**Solution**

With the help of `CukeModeler::Feature#rules`, a small line adds rules tests into tests collection in `FileExtractor#extract`:

``` ruby
module CukeSlicer::FileExtractor
    def extract(target, filters, format, &block)
      # ...

      tests = target.feature.tests
      tests += target.feature.rules.flat_map(&:tests)

      runnable_elements = extract_runnable_elements(extract_runnable_block_elements(tests, filters, &block))
      # ...
   end
end
```

**Changes**

* Change `FileExtractor#extract` to include tests provided by rules
* Use `CukeModeler::Feature#rules` to find these Rules
* Add cucumber scenario using Rule keyword